### PR TITLE
feat: add a way to customize actions overflow

### DIFF
--- a/src/Definition/AbstractDefinition.php
+++ b/src/Definition/AbstractDefinition.php
@@ -37,6 +37,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -46,9 +47,13 @@ use WhiteOctober\BreadcrumbsBundle\Model\Breadcrumbs;
 
 abstract class AbstractDefinition implements DefinitionInterface, ServiceSubscriberInterface
 {
+    public const OPT_ACTIONS_OVERFLOW = 'actions_overflow';
+
     protected ContainerInterface $container;
 
     protected TranslatorInterface $translator;
+
+    protected array $options = [];
 
     /**
      * @var \araise\CoreBundle\Action\Action[]
@@ -95,6 +100,31 @@ abstract class AbstractDefinition implements DefinitionInterface, ServiceSubscri
         }
 
         return new $className();
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    public function setOption(string $key, $value): static
+    {
+        $resolver = new OptionsResolver();
+        $this->configureOptions($resolver);
+
+        $this->options[$key] = $value;
+        $this->options = $resolver->resolve($this->options);
+
+        return $this;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            self::OPT_ACTIONS_OVERFLOW => 3,
+        ]);
+
+        $resolver->setAllowedTypes(self::OPT_ACTIONS_OVERFLOW, ['integer']);
     }
 
     public function addAction(string $acronym, array $options = [], string $type = Action::class): static
@@ -172,6 +202,10 @@ abstract class AbstractDefinition implements DefinitionInterface, ServiceSubscri
     public function getBatchActions(): array
     {
         return $this->batchActions;
+    }
+
+    public function configureDefinition(): void
+    {
     }
 
     public function configureView(DefinitionBuilder $builder, mixed $data): void
@@ -888,6 +922,7 @@ abstract class AbstractDefinition implements DefinitionInterface, ServiceSubscri
         if ($cache === null || $data !== null) {
             $builder = $this->container->get(DefinitionBuilder::class);
             $builder->setDefinition($this);
+            $this->configureDefinition();
             $this->configureActions($data);
             $this->configureView($builder, $data);
 

--- a/src/Definition/DefinitionInterface.php
+++ b/src/Definition/DefinitionInterface.php
@@ -63,6 +63,11 @@ interface DefinitionInterface
      */
     public static function getCapabilities(): array;
 
+    /**
+     * returns options of this definition.
+     */
+    public function getOptions(): array;
+
     public function getActions(): array;
 
     /**

--- a/src/Resources/views/includes/topbar/_actions.html.twig
+++ b/src/Resources/views/includes/topbar/_actions.html.twig
@@ -3,7 +3,7 @@
         {% set nextAction = view.actions|filter((item, key) => item.acronym == 'next' and key < 3) %}
         {% set prevAction = view.actions|filter((item, key) => item.acronym == 'prev' and key < 3) %}
 
-        {% set overflow = 3 %}
+        {% set overflow = view.definition.options.actions_overflow is defined ? view.definition.options.actions_overflow : 3 %}
         {% set overflow = nextAction ? overflow + 1 : overflow %}
         {% set overflow = prevAction ? overflow + 1 : overflow %}
         {% set overflow0 = overflow - 1 %}


### PR DESCRIPTION
Adds a way to change how many action buttons are displayed before grouping them with a "more" button

# Test:
Use this code snippet in a definition to test this feature:
```php
public function configureDefinition(): void {
    parent::configureDefinition();

    $this->setOption(self::OPT_ACTIONS_OVERFLOW, 2);
}
```