### PR TITLE
Docs: adapt filters to new version

### DIFF
--- a/docs/cookbook/filters.md
+++ b/docs/cookbook/filters.md
@@ -36,8 +36,10 @@ public function configureFilters(Table $table)
 {
     parent::configureFilters($table);
     $table->getFilterExtension()
-        ->addFilter('age', 'Age', new NumberFilterType(self::getQueryAlias() . '.age'));
-    // addFilter(acronym, label, FilterType)
+        ->addFilterType('age', 'Age', NumberFilterType::class, [
+            FilterType::OPT_COLUMN => (self::getQueryAlias() . '.age')
+        ]);
+    // addFilterType(acronym, label, FilterType, options)
 }
 ```
 


### PR DESCRIPTION
Make the documentation match the new behaviour.

Affects this page and section: https://crud.docs.araise.dev/#/cookbook/filters?id=how-to-add-a-custom-filter