### PR TITLE
fix: make one-to-one relation work by using isset check

### DIFF
--- a/src/Content/RelationContent.php
+++ b/src/Content/RelationContent.php
@@ -553,7 +553,7 @@ class RelationContent extends AbstractContent
 
             $stack[$part] = [
                 '_mapping' => $mapping,
-                'field' => $mapping['mappedBy'] ?: $mapping['inversedBy'],
+                'field' => $mapping['mappedBy'] ?? $mapping['inversedBy'],
                 'path' => implode('.', array_keys($stack)),
             ];
         }


### PR DESCRIPTION
I had an issue where I had a one-to-one relation between two Entities and it could not be displayed. 

Whenever I tried to load a Definition where the owning-side Entity was rendered, I got the following error:

```
An exception has been thrown during the rendering of a template ("Unknown property "mappedBy" on class Doctrine\ORM\Mapping\OneToOneOwningSideMapping") in "@araiseCrud/includes/layout/_content.html.twig".
```

The problem here seems to be that the property "mappedBy" only exists if the mapping is a `OneToOneOwningSideMapping`. 

Instead of checking it with `instanceof` i opted for a `isset` check because of backwards-compatibility.