### PR TITLE
feat: align action buttons to the right without breadcrumbs

### DIFF
--- a/src/Resources/views/base.html.twig
+++ b/src/Resources/views/base.html.twig
@@ -127,7 +127,7 @@
                 </div>
 
                 {% block topbar %}
-                    <nav class="whatwedo_crud-topbar whatwedo-utility-topbar">
+                    <nav class="whatwedo_crud-topbar whatwedo-utility-topbar lg:gap-x-3">
                         {% block hamburger %}
                             <button {{ stimulus_action('araise/crud-bundle/offcanvas', 'showContent') }} type="button" class="inline-flex md:hidden items-center justify-center rounded-md text-neutral-500 hover:text-neutral-900 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary-500">
                                 <span class="sr-only">Open sidebar</span>

--- a/src/Resources/views/includes/topbar/_actions.html.twig
+++ b/src/Resources/views/includes/topbar/_actions.html.twig
@@ -1,5 +1,5 @@
 {% if view is defined and view.actions|length > 0 %}
-    <div class="hidden md:flex lg:ml-3 flex space-x-3 justify-end flex-nowrap items-stretch">
+    <div class="hidden md:flex lg:ms-auto flex space-x-3 justify-end flex-nowrap items-stretch">
         {% set nextAction = view.actions|filter((item, key) => item.acronym == 'next' and key < 3) %}
         {% set prevAction = view.actions|filter((item, key) => item.acronym == 'prev' and key < 3) %}
 


### PR DESCRIPTION
References: https://dev.whatwedo.ch/araise/araise-meta/-/issues/121